### PR TITLE
Cache finished task even if there's no listener attached

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 Antonis Kalou
+Mátyás Fodor

--- a/wscelery/events.py
+++ b/wscelery/events.py
@@ -95,15 +95,16 @@ class EventHandler:
             except KeyError:
                 continue
 
+            # Record finished tasks in-case they are requested
+            # too late or are re-requested.
+            if event['type'] in self.finished_events:
+                self.finished_tasks[task_id] = event
+
             try:
                 callback = self.listeners[task_id]
             except KeyError:
                 pass
             else:
-                # Record finished tasks in-case they are requested
-                # too late or are re-requested.
-                if event['type'] in self.finished_events:
-                    self.finished_tasks[task_id] = event
                 callback(event)
 
     def stop(self):


### PR DESCRIPTION
I found a bug, which causes tasks with no listener attached to be thrown away instead of recorded in the finished tasks LRUCache.

## Description
I removed the event recording functionality from the try - exec block's else statement, so now events are recorded even if there's no corresponding listener found.
